### PR TITLE
feat: add build step for Node.js and TypeScript consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Install dependencies:
 
 `bun install`
 
+Build (produces `dist/` for Node.js and TypeScript consumers; Bun uses raw source directly):
+
+`bun run build`
+
 Test:
 
 `bun test`

--- a/package.json
+++ b/package.json
@@ -14,6 +14,13 @@
     "type": "git",
     "url": "git+https://github.com/flowscripter/template-bun-library.git"
   },
+  "files": [
+    "dist",
+    "src",
+    "index.ts",
+    "README.md",
+    "LICENSE"
+  ],
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -25,18 +32,11 @@
       "default": "./dist/index.js"
     }
   },
-  "files": [
-    "dist",
-    "src",
-    "index.ts",
-    "README.md",
-    "LICENSE"
-  ],
-  "scripts": {
-    "build": "bun build index.ts --outdir dist && tsc -p tsconfig.build.json"
-  },
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "build": "bun build index.ts --outdir dist && tsc -p tsconfig.build.json"
   },
   "devDependencies": {
     "@types/bun": "^1.3.14",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,26 @@
     "url": "git+https://github.com/flowscripter/template-bun-library.git"
   },
   "type": "module",
-  "module": "index.ts",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "bun": "./index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src",
+    "index.ts",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "bun build index.ts --outdir dist && tsc -p tsconfig.build.json"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rewriteRelativeImportExtensions": true
+  }
+}


### PR DESCRIPTION
## Summary

- Add `bun run build` script: runs `bun build index.ts --outdir dist` then `tsc -p tsconfig.build.json`
- Add `tsconfig.build.json` extending the base config with `emitDeclarationOnly`, `declaration`, `declarationMap`, `rewriteRelativeImportExtensions`, and `outDir: dist`
- Update `package.json` with `main`, `types`, `exports` (with `bun` condition for raw source), and `files` fields
- Update README with build step documentation

Bun consumers use raw `.ts` source via the `bun` exports condition. Node.js and TypeScript consumers use `dist/index.js` and `dist/index.d.ts`.

## Test plan

- [ ] `bun install && bun run build` produces `dist/index.js` and `dist/index.d.ts`
- [ ] CI workflow runs `bun run build` before semantic-release (after `.github` v1 branch update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)